### PR TITLE
Easily override default metadata mapping

### DIFF
--- a/docs/customizing_metadata.md
+++ b/docs/customizing_metadata.md
@@ -1,0 +1,43 @@
+# Customizing metadata import
+
+Often the data you will want to import will not conform exactly to the fields you get from `Hyrax::BasicMetadata`, in which case you will need to make a custom mapper.
+
+Again, let's start with making a test. Make a file called `spec/importers/custom_mapper.rb`. Let's start by describing the CSV we expect to import:
+
+```ruby
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomMapper do
+  subject(:mapper) { described_class.new }
+
+  let(:metadata) do
+    { "Name.architect" => "Imhotep", # architect
+      "Type.genre" => "Journalism" # genre
+    }
+
+    describe '#fields' do
+    it 'has expected fields' do
+      expect(mapper.fields).to include(
+        :architect,
+        :genre
+      )
+    end
+  end
+```
+From this rspec test, I can conclude that I have two customized metadata fields, `architect` and `genre`. Actually adding custom metadata fields is covered elsewhere (See [this guide](https://samvera.github.io/customize-metadata-generate-work-type.html), for example), so here we are just going to assume that these fields exist already, and are defined as multi-valued strings.
+
+
+* Put a file in `config/initializers/zizia.rb`
+
+It should look like this:
+
+```ruby
+Zizia.config do |config|
+  config.metadata_mapper_class = CustomMapper
+  config.default_info_stream = Rails.logger
+  config.default_error_stream = Rails.logger
+end
+```
+This tells zizia what class to use for metadata mappings, and where to log the output.

--- a/lib/zizia.rb
+++ b/lib/zizia.rb
@@ -34,6 +34,19 @@ module Zizia
   module_function :config
 
   require 'zizia/log_stream'
+  require 'zizia/version'
+  require 'zizia/metadata_mapper'
+  require 'zizia/hash_mapper'
+  require 'zizia/hyrax_basic_metadata_mapper'
+  require 'zizia/importer'
+  require 'zizia/record_importer'
+  require 'zizia/hyrax_record_importer'
+  require 'zizia/input_record'
+  require 'zizia/validator'
+  require 'zizia/validators/csv_format_validator'
+  require 'zizia/validators/title_validator'
+  require 'zizia/parser'
+
   ##
   # Module-wide options for `Zizia`.
   class Configuration
@@ -42,32 +55,19 @@ module Zizia
     #   @return [#<<]
     # @!attribute [rw] default_info_stream
     #   @return [#<<]
-    attr_accessor :default_error_stream, :default_info_stream
+    attr_accessor :default_error_stream
+    attr_accessor :default_info_stream
+    attr_accessor :metadata_mapper_class
 
     def initialize
       self.default_error_stream = Zizia::LogStream.new
       self.default_info_stream  = Zizia::LogStream.new
+      self.metadata_mapper_class = Zizia::HyraxBasicMetadataMapper
     end
   end
 
   @configuration = Configuration.new
 
-  require 'zizia/version'
-  require 'zizia/metadata_mapper'
-  require 'zizia/hash_mapper'
-  require 'zizia/hyrax_basic_metadata_mapper'
-
-  require 'zizia/importer'
-  require 'zizia/record_importer'
-  require 'zizia/hyrax_record_importer'
-
-  require 'zizia/input_record'
-
-  require 'zizia/validator'
-  require 'zizia/validators/csv_format_validator'
-  require 'zizia/validators/title_validator'
-
-  require 'zizia/parser'
   require 'zizia/parsers/csv_parser'
   require 'zizia/metadata_only_stack'
 end

--- a/lib/zizia/input_record.rb
+++ b/lib/zizia/input_record.rb
@@ -14,7 +14,7 @@ module Zizia
 
     ##
     # @param mapper [#map_fields]
-    def initialize(mapper: HyraxBasicMetadataMapper.new)
+    def initialize(mapper: Zizia.config.metadata_mapper_class.new)
       self.mapper = mapper
     end
 
@@ -25,7 +25,7 @@ module Zizia
       #
       # @return [InputRecord] an input record mapping metadata with the given
       #   mapper
-      def from(metadata:, mapper: HyraxBasicMetadataMapper.new)
+      def from(metadata:, mapper: Zizia.config.metadata_mapper_class.new)
         mapper.metadata = metadata
         new(mapper: mapper)
       end

--- a/spec/zizia_spec.rb
+++ b/spec/zizia_spec.rb
@@ -2,6 +2,9 @@
 
 require 'spec_helper'
 
+class FakeMetadataMapper
+end
+
 describe Zizia do
   describe '#config' do
     it 'can set a default error stream' do
@@ -14,6 +17,16 @@ describe Zizia do
       expect { described_class.config { |c| c.default_info_stream = STDOUT } }
         .to change { described_class.config.default_info_stream }
         .to(STDOUT)
+    end
+
+    it 'has a default metadata mapper' do
+      expect(described_class.config.metadata_mapper_class).to eq Zizia::HyraxBasicMetadataMapper
+    end
+
+    it 'can set a default metadata mapper' do
+      expect { described_class.config { |c| c.metadata_mapper_class = FakeMetadataMapper } }
+        .to change { described_class.config.metadata_mapper_class }
+        .to(FakeMetadataMapper)
     end
   end
 end


### PR DESCRIPTION
Make it easier to insert custom metadata mappings.
Document how to do this.

Connected to https://github.com/curationexperts/dlp-curate/issues/11