### PR TITLE
Change paths in CSS and JS to work in parent Rails app

### DIFF
--- a/app/assets/javascripts/zizia/zizia.js
+++ b/app/assets/javascripts/zizia/zizia.js
@@ -1,6 +1,6 @@
 var Zizia = {
   displayUploadedFile: function() {
-    var DisplayUploadedFile = require('./DisplayUploadedFile')
+    var DisplayUploadedFile = require('zizia/DisplayUploadedFile')
     new DisplayUploadedFile().display()
   }
 }

--- a/app/assets/stylesheets/zizia/zizia.scss
+++ b/app/assets/stylesheets/zizia/zizia.scss
@@ -1,1 +1,1 @@
-@require 'file-upload';
+@import 'file_upload';

--- a/lib/zizia/engine.rb
+++ b/lib/zizia/engine.rb
@@ -9,6 +9,10 @@ module Zizia
   class Engine < ::Rails::Engine
     isolate_namespace Zizia
 
+    initializer :zizia_assets_precompile do |app|
+      app.config.assets.precompile << %w[zizia/application.js zizia/application.css]
+    end
+
     initializer :append_migrations do |app|
       unless app.root.to_s.match root.to_s
         config.paths['db/migrate'].expanded.each do |expanded_path|

--- a/lib/zizia/version.rb
+++ b/lib/zizia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zizia
-  VERSION = '2.1.0.alpha.04'
+  VERSION = '2.1.0.alpha.05'
 end

--- a/zizia.gemspec
+++ b/zizia.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rails', '~> 5.1.7'
   gem.add_dependency 'carrierwave'
   gem.add_dependency 'redcarpet'
+  gem.add_dependency 'sassc-rails'
 
   gem.add_development_dependency 'yard'
   gem.add_development_dependency 'bixby'


### PR DESCRIPTION
This alters the paths in the JS and CSS files so
that these files are included when the Engine is used
in a Rails app.