### PR TITLE
Fixes for path settings

### DIFF
--- a/app/uploaders/zizia/csv_manifest_uploader.rb
+++ b/app/uploaders/zizia/csv_manifest_uploader.rb
@@ -12,11 +12,11 @@ module Zizia
 
     # The directory where the csv manifest will be stored.
     def store_dir
-      configured_upload_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      Rails.root.join('tmp', 'csv_uploads')
     end
 
     def cache_dir
-      configured_cache_path + "#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+      Rails.root.join('tmp', 'csv_uploads_cache')
     end
 
     # Add a white list of extensions which are allowed to be uploaded.
@@ -45,22 +45,6 @@ module Zizia
       def validate_csv
         @validator = CsvManifestValidator.new(self)
         @validator.validate
-      end
-
-      def configured_upload_path
-        ENV['CSV_MANIFESTS_PATH'] || base_path_uploads + 'csv_uploads'
-      end
-
-      def configured_cache_path
-        ENV['CSV_MANIFESTS_CACHE_PATH'] || base_path_cache + 'csv_uploads/cache'
-      end
-
-      def base_path_uploads
-        ENV['TRAVIS'] ? Rails.root : Hyrax.config.upload_path.call
-      end
-
-      def base_path_cache
-        ENV['TRAVIS'] ? Rails.root : Hyrax.config.cache_path.call
       end
   end
 end

--- a/lib/zizia/version.rb
+++ b/lib/zizia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zizia
-  VERSION = '2.1.0.alpha.06'
+  VERSION = '2.1.0.alpha.07'
 end

--- a/spec/uploaders/csv_manifest_uploader_spec.rb
+++ b/spec/uploaders/csv_manifest_uploader_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Zizia::CsvManifestUploader, type: :model do
+  subject(:csv_uploader) { described_class.new }
+
+  it 'has a a store dir' do
+    expect(csv_uploader.store_dir.to_s).to match(/uploads/)
+  end
+
+  it 'has a cache dir' do
+    expect(csv_uploader.cache_dir.to_s).to match(/cache/)
+  end
+
+  it 'has an extension whitelist' do
+    expect(csv_uploader.extension_whitelist).to eq(%w[csv])
+  end
+
+  it 'returns an empty array if the validator has no errors' do
+    expect(csv_uploader.errors).to eq([])
+  end
+
+  it 'has warnings' do
+    expect(csv_uploader.warnings).to eq([])
+  end
+
+  it 'has records' do
+    expect(csv_uploader.records).to eq(0)
+  end
+end


### PR DESCRIPTION
The pre-engine version of this code
relied on Hyrax config settings. This
simplifies it so that it only uses
`Rails.root` to determine the path.