### PR TITLE
Make zizia events easier to find in logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    samvera: samvera/circleci-orb@dev:fix-bundle-cache
+    samvera: samvera/circleci-orb@0.3.1
 jobs:
     build:
         parameters:

--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -24,7 +24,7 @@ class ModularImporter
 
     file = File.open(@csv_file)
 
-    Zizia.config.default_info_stream << "event: start_import, batch_id: #{@csv_import.id}, collection_id: #{@collection_id}, user: #{@user_email}"
+    Zizia.config.default_info_stream << "[zizia] event: start_import, batch_id: #{@csv_import.id}, collection_id: #{@collection_id}, user: #{@user_email}"
     Zizia::Importer.new(parser: Zizia::CsvParser.new(file: file), record_importer: Zizia::HyraxRecordImporter.new(attributes: attrs)).import
     file.close
   end

--- a/lib/zizia/hyrax_record_importer.rb
+++ b/lib/zizia/hyrax_record_importer.rb
@@ -193,7 +193,7 @@ module Zizia
       # We assume the object was created as expected if the actor stack returns true.
       # Note that for now the update stack will only update metadata and update collection membership, it will not re-import files.
       def update_for(existing_record:, update_record:)
-        info_stream << "event: record_update_started, batch_id: #{batch_id}, collection_id: #{collection_id}, #{deduplication_field}: #{update_record.respond_to?(deduplication_field) ? update_record.send(deduplication_field) : update_record}"
+        info_stream << "[zizia] event: record_update_started, batch_id: #{batch_id}, collection_id: #{collection_id}, #{deduplication_field}: #{update_record.respond_to?(deduplication_field) ? update_record.send(deduplication_field) : update_record}"
         additional_attrs = {
           depositor: @depositor.user_key
         }
@@ -211,11 +211,11 @@ module Zizia
 
         actor_env = Hyrax::Actors::Environment.new(existing_record, ::Ability.new(@depositor), attrs)
         if metadata_only_middleware.update(actor_env)
-          info_stream << "event: record_updated, batch_id: #{batch_id}, record_id: #{existing_record.id}, collection_id: #{collection_id}, #{deduplication_field}: #{existing_record.respond_to?(deduplication_field) ? existing_record.send(deduplication_field) : existing_record}"
+          info_stream << "[zizia] event: record_updated, batch_id: #{batch_id}, record_id: #{existing_record.id}, collection_id: #{collection_id}, #{deduplication_field}: #{existing_record.respond_to?(deduplication_field) ? existing_record.send(deduplication_field) : existing_record}"
           @success_count += 1
         else
           existing_record.errors.each do |attr, msg|
-            error_stream << "event: validation_failed, batch_id: #{batch_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}"
+            error_stream << "[zizia] event: validation_failed, batch_id: #{batch_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}"
           end
           @failure_count += 1
         end
@@ -224,7 +224,7 @@ module Zizia
       # Create an object using the Hyrax actor stack
       # We assume the object was created as expected if the actor stack returns true.
       def create_for(record:)
-        info_stream << "event: record_import_started, batch_id: #{batch_id}, collection_id: #{collection_id}, record_title: #{record.respond_to?(:title) ? record.title : record}"
+        info_stream << "[zizia] event: record_import_started, batch_id: #{batch_id}, collection_id: #{collection_id}, record_title: #{record.respond_to?(:title) ? record.title : record}"
 
         additional_attrs = {
           uploaded_files: create_upload_files(record),
@@ -248,11 +248,11 @@ module Zizia
                                                    attrs)
 
         if Hyrax::CurationConcern.actor.create(actor_env)
-          info_stream << "event: record_created, batch_id: #{batch_id}, record_id: #{created.id}, collection_id: #{collection_id}, record_title: #{attrs[:title]&.first}"
+          info_stream << "[zizia] event: record_created, batch_id: #{batch_id}, record_id: #{created.id}, collection_id: #{collection_id}, record_title: #{attrs[:title]&.first}"
           @success_count += 1
         else
           created.errors.each do |attr, msg|
-            error_stream << "event: validation_failed, batch_id: #{batch_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}"
+            error_stream << "[zizia] event: validation_failed, batch_id: #{batch_id}, collection_id: #{collection_id}, attribute: #{attr.capitalize}, message: #{msg}, record_title: record_title: #{attrs[:title] ? attrs[:title] : attrs}"
           end
           @failure_count += 1
         end

--- a/lib/zizia/importer.rb
+++ b/lib/zizia/importer.rb
@@ -40,8 +40,8 @@ module Zizia
 
     # Do not attempt to run an import if there are no records. Instead, just write to the log.
     def no_records_message
-      @info_stream << "event: empty_import, batch_id: #{record_importer.batch_id}"
-      @error_stream << "event: empty_import, batch_id: #{record_importer.batch_id}"
+      @info_stream << "[zizia] event: empty_import, batch_id: #{record_importer.batch_id}"
+      @error_stream << "[zizia] event: empty_import, batch_id: #{record_importer.batch_id}"
     end
 
     ##
@@ -51,11 +51,11 @@ module Zizia
     def import
       no_records_message && return unless records.count.positive?
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      @info_stream << "event: start_import, batch_id: #{record_importer.batch_id}, expecting to import #{records.count} records."
+      @info_stream << "[zizia] event: start_import, batch_id: #{record_importer.batch_id}, expecting to import #{records.count} records."
       records.each { |record| record_importer.import(record: record) }
       end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elapsed_time = end_time - start_time
-      @info_stream << "event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}, elapsed_time: #{elapsed_time}, elapsed_time_per_record: #{elapsed_time / records.count}"
+      @info_stream << "[zizia] event: finish_import, batch_id: #{record_importer.batch_id}, successful_record_count: #{record_importer.success_count}, failed_record_count: #{record_importer.failure_count}, elapsed_time: #{elapsed_time}, elapsed_time_per_record: #{elapsed_time / records.count}"
     end
   end
 end

--- a/spec/zizia/csv_template_spec.rb
+++ b/spec/zizia/csv_template_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper'
 RSpec.describe Zizia::CsvTemplate do
   let(:csv_template) { described_class.new }
 
+  before do
+    Zizia.config.metadata_mapper_class = Zizia::HyraxBasicMetadataMapper
+  end
+
   it 'returns a CSV string based on the headers in the Hyrax mapper' do
     expect(csv_template.to_s).to eq(Zizia::HyraxBasicMetadataMapper.new.fields.join(','))
   end

--- a/spec/zizia/csv_template_spec.rb
+++ b/spec/zizia/csv_template_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe Zizia::CsvTemplate do
   let(:csv_template) { described_class.new }
 
-  it 'retruns a CSV string based on the headers in the Hyrax mapper' do
+  it 'returns a CSV string based on the headers in the Hyrax mapper' do
     expect(csv_template.to_s).to eq(Zizia::HyraxBasicMetadataMapper.new.fields.join(','))
   end
 end


### PR DESCRIPTION
Prefix all zizia events with a [zizia] string for ease of searching in
logs.

Connected to https://github.com/curationexperts/dlp-curate/issues/16