### PR TITLE
Check for existing roles

### DIFF
--- a/db/migrate/20190919145012_user_roles.rb
+++ b/db/migrate/20190919145012_user_roles.rb
@@ -1,14 +1,16 @@
 class UserRoles < ActiveRecord::Migration[5.0]
   def up
-    create_table :roles do |t|
-      t.string :name
+    unless table_exists?(:roles)
+      create_table :roles do |t|
+        t.string :name
+      end
+      create_table :roles_users, :id => false do |t|
+        t.references :role
+        t.references :user
+      end
+      add_index :roles_users, [:role_id, :user_id]
+      add_index :roles_users, [:user_id, :role_id]
     end
-    create_table :roles_users, :id => false do |t|
-      t.references :role
-      t.references :user
-    end
-    add_index :roles_users, [:role_id, :user_id]
-    add_index :roles_users, [:user_id, :role_id]
   end
 
   def down

--- a/lib/zizia/version.rb
+++ b/lib/zizia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zizia
-  VERSION = '4.0.2.alpha.01'
+  VERSION = '4.0.3.alpha.01'
 end

--- a/lib/zizia/version.rb
+++ b/lib/zizia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zizia
-  VERSION = '4.0.3.alpha.01'
+  VERSION = '4.1.0.alpha.01'
 end

--- a/zizia.gemspec
+++ b/zizia.gemspec
@@ -11,9 +11,8 @@ Gem::Specification.new do |gem|
   gem.email         = ['administrator@curationexperts.com']
   gem.summary       = 'Hyrax importers.'
   gem.license       = 'Apache-2.0'
-  gem.files         = %w[README.md] +
-                      Dir.glob('{app,config,db,lib}/**/*}')
-  gem.require_paths = ['.']
+  gem.files         = `git ls-files`.split("\n")
+  gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 2.3.4'
 

--- a/zizia.gemspec
+++ b/zizia.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |gem|
   gem.summary       = 'Hyrax importers.'
   gem.license       = 'Apache-2.0'
   gem.files         = %w[README.md] +
-                      Dir.glob('lib/**/*.rb')
-  gem.require_paths = %w[lib]
+                      Dir.glob('{app,config,db,lib}/**/*}')
+  gem.require_paths = ['.']
 
   gem.required_ruby_version = '>= 2.3.4'
 


### PR DESCRIPTION
This adds a check to the Roles migration needed for testing. This may already exist in the apps' migrations. 