### PR TITLE
Return attrs from process_attrs method

### DIFF
--- a/lib/zizia.rb
+++ b/lib/zizia.rb
@@ -36,6 +36,7 @@ module Zizia
   require 'zizia/metadata_mapper'
   require 'zizia/hash_mapper'
   require 'zizia/hyrax/hyrax_basic_metadata_mapper'
+  require 'zizia/hyrax/based_near_attributes'
   require 'zizia/importer'
   require 'zizia/record_importer'
   require 'zizia/hyrax/hyrax_record_importer'

--- a/lib/zizia/hyrax/based_near_attributes.rb
+++ b/lib/zizia/hyrax/based_near_attributes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Zizia
+  class BasedNearAttributes
+    attr_accessor :based_near
+
+    def initialize(based_near)
+      @based_near = based_near
+    end
+
+    ##
+    # When submitting location data (a.k.a. the "based near" attribute) via the UI,
+    # Hyrax expects to receive a `based_near_attributes` hash in a specific format.
+    # We need to take geonames urls as provided by the customer and transform them to
+    # mimic what the Hyrax UI would ordinarily produce. These will get turned into
+    # Hyrax::ControlledVocabularies::Location objects upon ingest.
+    # The expected hash looks like this:
+    #   "based_near_attributes"=>
+    #     {
+    #       "0"=> {
+    #               "id"=>"http://sws.geonames.org/5667009/", "_destroy"=>""
+    #             },
+    #       "1"=> {
+    #               "id"=>"http://sws.geonames.org/6252001/", "_destroy"=>""
+    #             },
+    #   }
+    # @return [Hash] a "based_near_attributes" hash as
+    def to_h
+      original_geonames_uris = based_near
+      return if original_geonames_uris.empty?
+      based_near_attributes = {}
+      original_geonames_uris.each_with_index do |uri, i|
+        based_near_attributes[i.to_s] = { 'id' => uri_to_sws(uri), "_destroy" => "" }
+      end
+      based_near_attributes
+    end
+
+    #
+    # Take a user-facing geonames URI and return an sws URI, of the form Hyrax expects
+    # (e.g., "http://sws.geonames.org/6252001/")
+    # @param [String] uri
+    # @return [String] an sws style geonames uri
+    def uri_to_sws(uri)
+      uri = URI(uri)
+      geonames_number = uri.path.split('/')[1]
+      "http://sws.geonames.org/#{geonames_number}/"
+    end
+  end
+end

--- a/lib/zizia/hyrax/hyrax_record_importer.rb
+++ b/lib/zizia/hyrax/hyrax_record_importer.rb
@@ -140,44 +140,6 @@ module Zizia
       filepath
     end
 
-    ##
-    # When submitting location data (a.k.a. the "based near" attribute) via the UI,
-    # Hyrax expects to receive a `based_near_attributes` hash in a specific format.
-    # We need to take geonames urls as provided by the customer and transform them to
-    # mimic what the Hyrax UI would ordinarily produce. These will get turned into
-    # Hyrax::ControlledVocabularies::Location objects upon ingest.
-    # The expected hash looks like this:
-    #   "based_near_attributes"=>
-    #     {
-    #       "0"=> {
-    #               "id"=>"http://sws.geonames.org/5667009/", "_destroy"=>""
-    #             },
-    #       "1"=> {
-    #               "id"=>"http://sws.geonames.org/6252001/", "_destroy"=>""
-    #             },
-    #   }
-    # @return [Hash] a "based_near_attributes" hash as
-    def based_near_attributes(based_near)
-      original_geonames_uris = based_near
-      return if original_geonames_uris.empty?
-      based_near_attributes = {}
-      original_geonames_uris.each_with_index do |uri, i|
-        based_near_attributes[i.to_s] = { 'id' => uri_to_sws(uri), "_destroy" => "" }
-      end
-      based_near_attributes
-    end
-
-    #
-    # Take a user-facing geonames URI and return an sws URI, of the form Hyrax expects
-    # (e.g., "http://sws.geonames.org/6252001/")
-    # @param [String] uri
-    # @return [String] an sws style geonames uri
-    def uri_to_sws(uri)
-      uri = URI(uri)
-      geonames_number = uri.path.split('/')[1]
-      "http://sws.geonames.org/#{geonames_number}/"
-    end
-
     private
 
       # Update an existing object using the Hyrax actor stack
@@ -218,7 +180,8 @@ module Zizia
         # since this is reserved for Hyrax and is where uploaded_files will be attached
         attrs.delete(:files)
         based_near = attrs.delete(:based_near)
-        attrs.merge(based_near_attributes: based_near_attributes(based_near)) unless based_near.nil? || based_near.empty?
+        attrs = attrs.merge(based_near_attributes: Zizia::BasedNearAttributes.new(based_near).to_h) unless based_near.nil? || based_near.empty?
+        attrs
       end
 
       # Create an object using the Hyrax actor stack


### PR DESCRIPTION
This method needs to return the attrs hash, this
fix is already in dlp-curate.

If this doesn't return, it will cause problems when
`based_near` aka `location` is blank in the CSV.