### PR TITLE
Explicitly include JS for the import UI

### DIFF
--- a/app/assets/stylesheets/zizia/zizia.scss
+++ b/app/assets/stylesheets/zizia/zizia.scss
@@ -1,1 +1,6 @@
 @import 'file_upload';
+
+.btn {
+    white-space:normal !important;
+    word-wrap: break-word;
+}

--- a/app/views/zizia/csv_imports/new.html.erb
+++ b/app/views/zizia/csv_imports/new.html.erb
@@ -1,2 +1,3 @@
+<%= javascript_include_tag 'zizia/application' %>
 <h2><span class="glyphicon glyphicon-cloud-upload"></span> Begin Your CSV Import </h2>
 <%= render 'form', csv_import: @csv_import %>

--- a/spec/dummy/spec/system/import_from_csv_spec.rb
+++ b/spec/dummy/spec/system/import_from_csv_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # Fill in and submit the form
       attach_file('csv_import[manifest]', csv_file, make_visible: true)
 
+      expect(page).to have_content('You sucessfully uploaded this CSV: all_fields.csv')
+
       click_on 'Preview Import'
 
       # We expect to see the title of the collection on the page


### PR DESCRIPTION
Normally you put this tag in a layout, but our UI only
needs the JS on one page.