### PR TITLE
Remove 'in Bytes' from import table headers

### DIFF
--- a/app/views/zizia/csv_import_details/show.html.erb
+++ b/app/views/zizia/csv_import_details/show.html.erb
@@ -11,7 +11,7 @@
   <table id="files-table" class="dataTable display responsive nowrap table table-striped works-list" style="width:100%">
     <tr>
       <th>Filename</th>
-      <th>Size in Bytes</th>
+      <th>Size</th>
       <th>Row Number</th>
     </tr>
 

--- a/lib/zizia/version.rb
+++ b/lib/zizia/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zizia
-  VERSION = '4.5.3.alpha.01'
+  VERSION = '4.5.4.alpha.01'
 end


### PR DESCRIPTION
They are human-readable now, not the plain
byte count.