### PR TITLE
Add field definitions for 'files' and 'visibility' to the field guide

### DIFF
--- a/app/lib/zizia/metadata_details.rb
+++ b/app/lib/zizia/metadata_details.rb
@@ -7,19 +7,9 @@ module Zizia
 
     def details(work_attributes:)
       validators = work_attributes.validators
-      work_attributes.properties.sort.map do |p|
-        Hash[
-          attribute: p[0],
-          predicate: p[1].predicate.to_s,
-          multiple: p[1].try(:multiple?).to_s,
-          type: type_to_s(p[1].type),
-          validator: validator_to_string(validator: validators[p[0].to_sym][0]),
-          label: I18n.t("simple_form.labels.defaults.#{p[0]}"),
-          csv_header: csv_header(p[0]),
-          required_on_form: required_on_form_to_s(p[0]),
-          usage: MetadataUsage.instance.usage[p[0]]
-        ]
-      end
+      detail_list = work_attributes.properties.sort.map { |p| definition_hash_for(p, validators) }
+      detail_list << visibility_definition
+      detail_list << file_definition
     end
 
     def to_csv(work_attributes:)
@@ -63,6 +53,48 @@ module Zizia
         else
           'No validation present in the model.'
         end
+      end
+
+      def definition_hash_for(field_properties, validators)
+        Hash[
+          attribute: field_properties[0],
+          predicate: field_properties[1].predicate.to_s,
+          multiple: field_properties[1].try(:multiple?).to_s,
+          type: type_to_s(field_properties[1].type),
+          validator: validator_to_string(validator: validators[field_properties[0].to_sym][0]),
+          label: I18n.t("simple_form.labels.defaults.#{field_properties[0]}"),
+          csv_header: csv_header(field_properties[0]),
+          required_on_form: required_on_form_to_s(field_properties[0]),
+          usage: MetadataUsage.instance.usage[field_properties[0]]
+        ]
+      end
+
+      def file_definition
+        {
+          attribute:  'files',
+          predicate:  'n/a',
+          multiple: 	'true',
+          type:       'String',
+          validator: 	'Required, must name a file on the server',
+          label: 	    'Items (listed at bottom of page)',
+          csv_header: 'files',
+          required_on_form: 	'true',
+          usage: MetadataUsage.instance.usage['files']
+        }
+      end
+
+      def visibility_definition
+        {
+          attribute:  'visibility',
+          predicate:  'n/a',
+          multiple: 	'false',
+          type:       'String',
+          validator: 	'Required, must exist in the application\'s controlled vocabulary for visiblity levels.',
+          label: 	    'Visibility',
+          csv_header: 'visibility',
+          required_on_form: 	'true',
+          usage: MetadataUsage.instance.usage['visibility']
+        }
       end
   end
 end

--- a/spec/controllers/metadata_details_spec.rb
+++ b/spec/controllers/metadata_details_spec.rb
@@ -54,11 +54,27 @@ RSpec.describe Zizia::MetadataDetailsController, type: :controller do
       expect(first_row).to include('required_on_form')
     end
 
-    it 'includes usage' do
+    it 'includes `usage`' do
       get :profile
       profile_table = CSV.parse(response.body, headers: :first_row)
       title_definition = profile_table.find { |r| r.field('attribute') == 'title' }
-      expect(title_definition.field('usage')).to include 'name of the resource being described' # match text extracted from ./config/emory/usage.yml
+      expect(title_definition.field('usage')).to include 'name of the resource being described' # match text extracted from ./config/zizia/usage.yml
+    end
+
+    it 'includes `files`' do
+      get :profile
+      profile_table = CSV.parse(response.body, headers: :first_row)
+      files_definition = profile_table.find { |r| r.field('attribute') == 'files' }
+      expect(files_definition.field('csv_header')).to eq('files')
+      expect(files_definition.field('validator')).to match(/Required/)
+    end
+
+    it 'includes `visibility`' do
+      get :profile
+      profile_table = CSV.parse(response.body, headers: :first_row)
+      visibility_definition = profile_table.find { |r| r.field('attribute') == 'visibility' }
+      expect(visibility_definition.field('csv_header')).to eq('visibility')
+      expect(visibility_definition.field('validator')).to match(/Required/)
     end
 
     it 'includes a date in the filename' do


### PR DESCRIPTION
Adds static definitions for the meta-fields required by the CSV importer.
* **files** one or more filenames to be attached as filesets to the work
* **visibility** the desired visibility level for the work and attached files