### PR TITLE
Set import details pagination to 10

### DIFF
--- a/app/models/zizia/csv_import_detail.rb
+++ b/app/models/zizia/csv_import_detail.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Zizia
   class CsvImportDetail < ::ApplicationRecord
+    paginates_per 10
+
     after_initialize :set_defaults, unless: :persisted?
 
     belongs_to :csv_import

--- a/spec/dummy/spec/system/csv_import_details_page_spec.rb
+++ b/spec/dummy/spec/system/csv_import_details_page_spec.rb
@@ -3,16 +3,18 @@ include Warden::Test::Helpers
 
 RSpec.describe 'viewing the csv import detail page' do
   let(:csv_import) { FactoryBot.create(:csv_import) }
-  let(:csv_import_detail) { FactoryBot.create(:csv_import_detail) }
+  let(:csv_import_detail) { FactoryBot.create_list(:csv_import_detail, 12) }
   let(:user) { FactoryBot.create(:admin) }
 
-  it 'displays the metadata when you visit the page' do
+  before do
     user.save
     csv_import.user_id = user.id
     csv_import.save
-    csv_import_detail.save
+    csv_import_detail.each(&:save)
     login_as user
+  end
 
+  it 'displays the metadata when you visit the page' do
     visit ('/csv_import_details/index')
     expect(page).to have_content('CSV Imports ID')
     click_on '1'
@@ -20,16 +22,20 @@ RSpec.describe 'viewing the csv import detail page' do
   end
 
   it 'has the dashboard layout' do
-    user.save
-    csv_import.user_id = user.id
-    csv_import.save
-    csv_import_detail.save
-    login_as user
-
     visit ('/csv_import_details/index')
     expect(page).to have_content('Your activity')
     visit ('csv_import_details/show/1')
     expect(page).to have_content('About the Import')
     expect(page).to have_content('Your activity')
+
+    visit('/csv_import_details/index')
+    expect(page).to have_content('Next')
+  end
+
+  it 'has pagination at 10' do
+    visit('/csv_import_details/index')
+    expect(page).to have_content('Next')
+    click_on 'Next'
+    expect(page).to have_content('Previous')
   end
 end


### PR DESCRIPTION
This sets the default pagination for `CsvImportDetail` objects
to 10.

See:

https://github.com/kaminari/kaminari#configuring-default-per_page-value-for-each-model-by-paginates_per

The page you are on is controlled with the page param. 1 will have 1-10, 2 will will have 10-20, etc.

Connected to https://github.com/curationexperts/in-house/issues/419