### PR TITLE
Add Date to details page

### DIFF
--- a/app/views/zizia/csv_import_details/index.html.erb
+++ b/app/views/zizia/csv_import_details/index.html.erb
@@ -3,6 +3,7 @@
   <tr>
     <th>ID</th>
     <th>Associated User</th>
+    <th>Date</th>
     <th>CSV File</th>
     <th>Number of Works</th>
     <th>Number of Files</th>
@@ -15,6 +16,9 @@
       </td>
       <td>
         <%= User.find(csv_import_detail.csv_import.user_id).email %>
+      </td>
+      <td>
+        <%= csv_import_detail.created_at.strftime("%B %-d, %Y %H:%M") %>
       </td>
       <td>
         <%= csv_import_detail.csv_import.manifest %>

--- a/spec/dummy/spec/system/csv_import_details_page_spec.rb
+++ b/spec/dummy/spec/system/csv_import_details_page_spec.rb
@@ -3,7 +3,7 @@ include Warden::Test::Helpers
 
 RSpec.describe 'viewing the csv import detail page' do
   let(:csv_import) { FactoryBot.create(:csv_import) }
-  let(:csv_import_detail) { FactoryBot.create_list(:csv_import_detail, 12) }
+  let(:csv_import_detail) { FactoryBot.create_list(:csv_import_detail, 12, created_at: Time.parse('Tue, 29 Oct 2019 14:20:02 UTC +00:00').utc) }
   let(:user) { FactoryBot.create(:admin) }
 
   before do
@@ -19,6 +19,19 @@ RSpec.describe 'viewing the csv import detail page' do
     expect(page).to have_content('CSV Imports ID')
     click_on '1'
     expect(page).to have_content('Total Size')
+  end
+
+  it 'displays the metadata when you visit the page' do
+    visit ('/csv_import_details/index')
+    expect(page).to have_content('CSV Imports ID')
+    click_on '1'
+    expect(page).to have_content('Total Size')
+  end
+
+  it 'displays the created_at date' do
+    visit ('/csv_import_details/index')
+    expect(page).to have_content('Date')
+    expect(page).to have_content('October 29, 2019 14:20')
   end
 
   it 'has the dashboard layout' do


### PR DESCRIPTION
This adds created_at to the csv import details
page. This is a `Time` object so it's formatted in
a more human readable way on the page:

`October 29, 2019 14:20`

Connected to https://github.com/curationexperts/in-house/issues/421