### PR TITLE
Only show the basename for PreIngestFile

### DIFF
--- a/app/models/zizia/pre_ingest_file.rb
+++ b/app/models/zizia/pre_ingest_file.rb
@@ -2,5 +2,9 @@
 module Zizia
   class PreIngestFile < ::ApplicationRecord
     belongs_to :pre_ingest_work
+
+    def basename
+      File.basename(filename)
+    end
   end
 end

--- a/app/views/zizia/csv_import_details/show.html.erb
+++ b/app/views/zizia/csv_import_details/show.html.erb
@@ -18,7 +18,7 @@
     <% @csv_import_detail.pre_ingest_files.each do |pre_ingest_file| %>
       <tr>
         <td>
-          <%= pre_ingest_file.filename %>
+          <%= pre_ingest_file.basename %>
         </td>
         <td>
           <%= number_to_human_size(pre_ingest_file.size) %>

--- a/spec/factories/pre_ingest_file.rb
+++ b/spec/factories/pre_ingest_file.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# This will guess the User class
+FactoryBot.define do
+  factory :pre_ingest_file, class: Zizia::PreIngestFile do
+    pre_ingest_work_id { 1 }
+    created_at { Time.current }
+    updated_at { Time.current }
+    row_number { 1 }
+    row { 'sample,row' }
+    filename { '/a/path/to/my.csv' }
+    size { 100_203_424 }
+  end
+end

--- a/spec/factories/pre_ingest_work.rb
+++ b/spec/factories/pre_ingest_work.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+# This will guess the User class
+FactoryBot.define do
+  factory :pre_ingest_work, class: Zizia::PreIngestWork do
+    id { 1 }
+    created_at { Time.current }
+    updated_at { Time.current }
+    csv_import_detail_id { 1 }
+  end
+end

--- a/spec/models/zizia/pre_ingest_file_spec.rb
+++ b/spec/models/zizia/pre_ingest_file_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Zizia::PreIngestFile do
+  let(:pre_ingest_work) { FactoryBot.create(:pre_ingest_work) }
+  let(:pre_ingest_file) { FactoryBot.create(:pre_ingest_file, pre_ingest_work_id: pre_ingest_work.id) }
+  let(:basename) { 'my.csv' }
+
+  it 'can get the basename for the file' do
+    expect(pre_ingest_file.basename).to eq(basename)
+  end
+end


### PR DESCRIPTION
This adds a method to the `PreIngestFile` model to get
the basename for the stored filepath.

Connected to https://github.com/curationexperts/in-house/issues/422