### PR TITLE
Add works to batch UI

### DIFF
--- a/app/models/zizia/pre_ingest_work.rb
+++ b/app/models/zizia/pre_ingest_work.rb
@@ -2,5 +2,15 @@
 module Zizia
   class PreIngestWork < ::ApplicationRecord
     has_many :pre_ingest_files
+
+    # Returns the title based on the deduplication_key if the work has been indexed to solr
+    # @return [String] the work's title
+    def title
+      return 'This work does not have a deduplication key.' if deduplication_key.nil?
+      solr_title = ActiveFedora::SolrService.get("deduplication_key_tesim:#{deduplication_key}")
+                                            .dig('response', 'docs', 0, 'title_tesim', 0)
+      return solr_title unless solr_title.nil?
+      'This work\'s metadata has not been indexed yet.'
+    end
   end
 end

--- a/app/views/zizia/csv_import_details/_pre_ingest_files_table.html.erb
+++ b/app/views/zizia/csv_import_details/_pre_ingest_files_table.html.erb
@@ -1,0 +1,20 @@
+<table id="files-table" class="dataTable display responsive nowrap table table-striped works-list" style="width:100%">
+  <tr>
+    <th>Filename</th>
+    <th>Size</th>
+    <th>Row Number</th>
+  </tr>
+  <% pre_ingest_work.pre_ingest_files.each do |pre_ingest_file| %>
+    <tr>
+      <td>
+        <%= pre_ingest_file.basename %>
+      </td>
+      <td>
+        <%= number_to_human_size(pre_ingest_file.size) %>
+      </td>
+      <td>
+        <%= pre_ingest_file.row_number %>
+      </td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/zizia/csv_import_details/show.html.erb
+++ b/app/views/zizia/csv_import_details/show.html.erb
@@ -7,26 +7,30 @@
     <li>Total Size: <%= number_to_human_size(@csv_import_detail.total_size) %></li>
   </ul>
 
-  <h3>Files</h3>
-  <table id="files-table" class="dataTable display responsive nowrap table table-striped works-list" style="width:100%">
-    <tr>
-      <th>Filename</th>
-      <th>Size</th>
-      <th>Row Number</th>
-    </tr>
+  <h3>Works & Files</h3>
 
-    <% @csv_import_detail.pre_ingest_files.each do |pre_ingest_file| %>
-      <tr>
-        <td>
-          <%= pre_ingest_file.basename %>
-        </td>
-        <td>
-          <%= number_to_human_size(pre_ingest_file.size) %>
-        </td>
-        <td>
-          <%= pre_ingest_file.row_number %>
-        </td>
-      </tr>
-    <% end %>
+  <table id="works-table" class="table works-list">
+    <tr>
+      <th>Deduplication Key</th>
+      <th>Title</th>
+      <th>Files</th>
+      <th>Date</th>
+    </tr>
+  <% @csv_import_detail.pre_ingest_works.each do |pre_ingest_work| %>
+    <tr>
+      <td>
+        <%= pre_ingest_work.deduplication_key%>
+      </td>
+      <td>
+        <%= pre_ingest_work.title %>
+      </td>
+      <td>
+        <%= render 'pre_ingest_files_table', pre_ingest_work: pre_ingest_work %>
+      </td>
+      <td>
+        <%= pre_ingest_work.created_at.strftime("%B %-d, %Y %H:%M") %>
+      </td>
+    </tr>
+  <% end %>
   </table>
 </div>

--- a/spec/dummy/app/models/work.rb
+++ b/spec/dummy/app/models/work.rb
@@ -8,6 +8,10 @@ class Work < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+
+  property :deduplication_key, predicate: 'http://metadata.example.com/vocab/predicates#deduplicationKey', multiple: false do |index|
+    index.as :stored_searchable
+  end
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/spec/dummy/spec/system/csv_import_details_page_spec.rb
+++ b/spec/dummy/spec/system/csv_import_details_page_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'viewing the csv import detail page' do
     expect(page).to have_content('undetermined')
     click_on '1'
     expect(page).to have_content('Total Size')
+    expect(page).to have_content('Deduplication Key')
   end
 
   it 'has links to sort' do

--- a/spec/models/zizia/pre_ingest_work_spec.rb
+++ b/spec/models/zizia/pre_ingest_work_spec.rb
@@ -2,8 +2,23 @@
 require 'rails_helper'
 
 RSpec.describe Zizia::PreIngestWork do
-  let(:pre_ingest_work) { FactoryBot.create(:pre_ingest_work, deduplication_key: "42") }
+  let(:pre_ingest_work) { FactoryBot.create(:pre_ingest_work, deduplication_key: '42') }
+  let(:pre_ingest_work_indexed) { FactoryBot.create(:pre_ingest_work, deduplication_key: '43') }
+  let(:work) { Work.new(title: ['A Nice Title'], deduplication_key: '43') }
+
+  before do
+    work.save
+  end
+
   it 'has a deduplication_key' do
-    expect(pre_ingest_work.deduplication_key).to eq "42"
+    expect(pre_ingest_work.deduplication_key).to eq '42'
+  end
+
+  it 'can return that metadata has not been indexed yet' do
+    expect(pre_ingest_work.title).to eq('This work\'s metadata has not been indexed yet.')
+  end
+
+  it 'can return a title for a work based on the deduplication key' do
+    expect(pre_ingest_work_indexed.title).to eq('A Nice Title')
   end
 end


### PR DESCRIPTION
This changes the files view to include `PreIngestWorks`.

The files are grouped by their `PreIngestWork`, which includes
the `deduplication_key` and `date`. This also includes the `title`,
which is looked up in solr via the `deduplication_key`. If this
isn't present for a work it means that the work has not been indexed
yet so a message saying that is displayed instead of the title.

Additional attributes from solr could be added in the future.

Connected to https://github.com/curationexperts/in-house/issues/426