### PR TITLE
Make deduplication_key a unique field in the database

### DIFF
--- a/app/importers/modular_importer.rb
+++ b/app/importers/modular_importer.rb
@@ -32,11 +32,12 @@ class ModularImporter
     }
 
     Rails.logger.info "[zizia] event: start_import, batch_id: #{@csv_import.id}, collection_id: #{@collection_id}, user: #{@user_email}"
+
     importer = Zizia::Importer.new(parser: Zizia::CsvParser.new(file: file), record_importer: Zizia::HyraxRecordImporter.new(attributes: attrs))
 
     importer.records.each_with_index do |record, index|
-      pre_ingest_work = Zizia::PreIngestWork.new(csv_import_detail_id: csv_import_detail.id, deduplication_key: record.mapper.metadata["deduplication_key"])
-
+      pre_ingest_work = Zizia::PreIngestWork.find_or_create_by(deduplication_key: record.mapper.metadata['deduplication_key'])
+      pre_ingest_work.csv_import_detail_id = csv_import_detail.id
       record.mapper.files.each do |child_file|
         full_path = Dir.glob("#{ENV['IMPORT_PATH']}/**/#{child_file}").first
         pre_ingest_file = Zizia::PreIngestFile.new(row_number: index + 1,

--- a/app/views/zizia/csv_import_details/_pre_ingest_files_table.html.erb
+++ b/app/views/zizia/csv_import_details/_pre_ingest_files_table.html.erb
@@ -3,6 +3,7 @@
     <th>Filename</th>
     <th>Size</th>
     <th>Row Number</th>
+    <th>Date Created</th>
   </tr>
   <% pre_ingest_work.pre_ingest_files.each do |pre_ingest_file| %>
     <tr>
@@ -14,6 +15,9 @@
       </td>
       <td>
         <%= pre_ingest_file.row_number %>
+      </td>
+      <td>
+        <%= pre_ingest_file.created_at.strftime("%B %-d, %Y %H:%M") %>
       </td>
     </tr>
   <% end %>

--- a/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
+++ b/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
@@ -1,0 +1,6 @@
+class AddUniquenessConstraintToPreIngestWorkDeduplicationKey < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :zizia_pre_ingest_works, :deduplication_key
+    add_index :zizia_pre_ingest_works, :deduplication_key, unique: true
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -605,7 +605,7 @@ ActiveRecord::Schema.define(version: 201901241536542) do
     t.datetime "updated_at", null: false
     t.string "deduplication_key"
     t.index ["csv_import_detail_id"], name: "index_zizia_pre_ingest_works_on_csv_import_detail_id"
-    t.index ["deduplication_key"], name: "index_zizia_pre_ingest_works_on_deduplication_key"
+    t.index ["deduplication_key"], name: "index_zizia_pre_ingest_works_on_deduplication_key", unique: true
   end
 
 end

--- a/spec/dummy/spec/system/import_from_csv_spec.rb
+++ b/spec/dummy/spec/system/import_from_csv_spec.rb
@@ -246,9 +246,13 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # Viewing additional details after an import
       visit "/csv_import_details/index"
       expect(page).to have_content('Total Size')
-      find(:xpath, '//*[@id="content-wrapper"]/div[2]/table/tbody/tr[3]/td[1]/a').click
+      click_on '4'
       expect(page).to have_content('dog.jpg')
+      expect(page).to have_content('cat.jpg')
       expect(page).to have_content('5.74 MB')
+      expect(page).to have_content('abc/123')
+      expect(page).to have_content('This work\'s metadata has not been indexed yet.')
+      expect(page).to have_content('Date Created')
     end
   end
 end


### PR DESCRIPTION
This changes the deduplication_key column for PreIngestWorks
so that it is a unique field. It also changes the way
PreIngestWorks are created in the `modular_importer` so that
only one is created per `deduplicaiton_key`. Before this
each row in the CSV was getting a `PreIngestWork`.