### PR TITLE
Check for exisiting deduplication_key index before removing

### DIFF
--- a/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
+++ b/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
@@ -1,6 +1,7 @@
 class AddUniquenessConstraintToPreIngestWorkDeduplicationKey < ActiveRecord::Migration[5.1]
   def change
-    remove_index :zizia_pre_ingest_works, :deduplication_key
+    remove_index :zizia_pre_ingest_works, :deduplication_key if index_exists?(:zizia_pre_ingest_works, :deduplication_key)
+
     add_index :zizia_pre_ingest_works, :deduplication_key, unique: true
   end
 end


### PR DESCRIPTION
If you run the migration from the previous commit and there
are exisiting non-unique records, the migration will fail.

The exisiting index will be removed, but when you run
migrations again they will fail because the index can
no longer be removed.