### PR TITLE
Remove contrainst from dedupekey

### DIFF
--- a/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
+++ b/db/migrate/20191105165518_add_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
@@ -1,6 +1,7 @@
 class AddUniquenessConstraintToPreIngestWorkDeduplicationKey < ActiveRecord::Migration[5.1]
   def change
-    remove_index :zizia_pre_ingest_works, :deduplication_key
+    remove_index :zizia_pre_ingest_works, :deduplication_key if index_exists?(:zizia_pre_ingest_works, :deduplication_key)
+
     add_index :zizia_pre_ingest_works, :deduplication_key, unique: true
   end
 end

--- a/db/migrate/20191105211127_remove_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
+++ b/db/migrate/20191105211127_remove_uniqueness_constraint_to_pre_ingest_work_deduplication_key.rb
@@ -1,0 +1,7 @@
+class RemoveUniquenessConstraintToPreIngestWorkDeduplicationKey < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :zizia_pre_ingest_works, :deduplication_key if index_exists?(:zizia_pre_ingest_works, :deduplication_key)
+
+    add_index :zizia_pre_ingest_works, :deduplication_key, unique: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -605,7 +605,7 @@ ActiveRecord::Schema.define(version: 201901241536542) do
     t.datetime "updated_at", null: false
     t.string "deduplication_key"
     t.index ["csv_import_detail_id"], name: "index_zizia_pre_ingest_works_on_csv_import_detail_id"
-    t.index ["deduplication_key"], name: "index_zizia_pre_ingest_works_on_deduplication_key", unique: true
+    t.index ["deduplication_key"], name: "index_zizia_pre_ingest_works_on_deduplication_key"
   end
 
 end


### PR DESCRIPTION
Adding a unique constraint to the `deduplication_key` solved
grouping for an initial import, but it causes problems when
you re-import. After a re-import `PreIngestFile`s are added to
the existing `PreIngestWork`s which are assoicated with existing
`CsvImportDetail`s.