### PR TITLE
Change count language on preview screen

### DIFF
--- a/app/views/zizia/csv_imports/_record_count.html.erb
+++ b/app/views/zizia/csv_imports/_record_count.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-8">
     <div class="alert alert-success">
-      <p> This import will create or update <%= @csv_import.manifest_records %> records. </p>
+      <p> This import will process <%= @csv_import.manifest_records %> row(s). </p>
     </div>
   </div>
 </div>

--- a/spec/dummy/spec/system/import_csv_with_warnings_spec.rb
+++ b/spec/dummy/spec/system/import_csv_with_warnings_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Importing records from a CSV file', type: :system, js: true do
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will create or update 3 records.'
+      expect(page).to have_content 'This import will process 3 row(s).'
 
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'

--- a/spec/dummy/spec/system/import_from_csv_spec.rb
+++ b/spec/dummy/spec/system/import_from_csv_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will create or update 1 records.'
+      expect(page).to have_content 'This import will process 1 row(s).'
 
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'
@@ -116,7 +116,7 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will create or update 1 records.'
+      expect(page).to have_content 'This import will process 1 row(s).'
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'
 
@@ -171,7 +171,7 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will create or update 2 records.'
+      expect(page).to have_content 'This import will process 2 row(s).'
 
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'
@@ -218,8 +218,7 @@ RSpec.describe 'Importing records from a CSV file', :perform_jobs, :clean, type:
       # We expect to see the title of the collection on the page
       expect(page).to have_content 'Testing Collection'
 
-      expect(page).to have_content 'This import will create or update 1 records.'
-
+      expect(page).to have_content 'This import will process 1 row(s).'
       # There is a link so the user can cancel.
       expect(page).to have_link 'Cancel', href: '/csv_imports/new?locale=en'
 


### PR DESCRIPTION
The format of the CSV files has changed so that
a single row is not a work. The count available
on the preview screen is a count of rows. This
changes the language to reflect that the number
is a count of rows and not records/works.

Connected to https://github.com/curationexperts/in-house/issues/43