### PR TITLE
Basic file status

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,7 @@ RSpec/DescribeClass:
 
 RSpec/ExampleLength:
   Exclude:
+    - 'spec/controllers/pre_ingest_works_controller_spec.rb'
     - 'spec/zizia/hyrax/hyrax_basic_metadata_mapper_spec.rb'
     - 'spec/integration/import_hyrax_csv.rb'
     - 'spec/integration/csv_import_detail_spec.rb'

--- a/app/assets/javascripts/zizia/zizia.js
+++ b/app/assets/javascripts/zizia/zizia.js
@@ -1,6 +1,48 @@
 var Zizia = {
-  displayUploadedFile: function() {
+  displayUploadedFile: function () {
     var DisplayUploadedFile = require('zizia/DisplayUploadedFile')
     new DisplayUploadedFile().display()
+  },
+  checkStatuses: function (options) {
+    var results = []
+    // Go through the list of thumbnails for the work based
+    // on the deduplicationKey
+    options.thumbnails.forEach(function (thumbnail) {
+      $.ajax({
+        type: 'HEAD',
+        url: thumbnail,
+        complete: function (xhr) {
+          // Request only the headers from the thumbnail url
+          // push the statuses into an array
+          results.push(xhr.getResponseHeader('status'))
+          // See how many urls are not returning 200
+          var missingThumbnailCount = results.filter(
+            function (status) {
+              if (status !== '200 OK') { return true }
+            }).length
+          // If there are any not returning 200, the work is still being processed
+          if (missingThumbnailCount > 0) {
+
+          } else {
+            Zizia.addSuccessClasses(options)
+          }
+        }
+      })
+    })
+  },
+  displayWorkStatus: function () {
+    $('[id^=work-status]').each(function () {
+	    var deduplicationKey = $(this)[0].id.split('work-status-')[1]
+	    $.get('/pre_ingest_works/thumbnails/' + deduplicationKey, function (data) {
+        data.deduplicationKey = deduplicationKey
+        Zizia.checkStatuses(data)
+      })
+    })
+  },
+  addSuccessClasses: function (options) {
+    $('#work-status-' + options.deduplicationKey + ' > span').removeClass('status-unknown')
+    $('#work-status-' + options.deduplicationKey + ' > span').removeClass('glyphicon-question-sign')
+    $('#work-status-' + options.deduplicationKey + ' > span').addClass('text-success')
+    $('#work-status-' + options.deduplicationKey + ' > span').addClass('glyphicon-ok-sign')
   }
 }

--- a/app/controllers/zizia/pre_ingest_works_controller.rb
+++ b/app/controllers/zizia/pre_ingest_works_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Zizia
+  class PreIngestWorksController < ::ApplicationController
+    before_action :merge_abilities
+    load_and_authorize_resource
+
+    def thumbnails
+      pre_ingest_work = Zizia::PreIngestWork.where(deduplication_key: pre_ingest_works_params[:deduplication_key]).first
+
+      @thumbnails = if pre_ingest_work
+                      pre_ingest_work.thumbnails
+                    else
+                      []
+                    end
+
+      respond_to do |format|
+        format.json { render json: { thumbnails: @thumbnails } }
+      end
+    end
+
+    private
+
+      def pre_ingest_works_params
+        params.permit(:deduplication_key, :format)
+      end
+
+      def merge_abilities
+        current_ability.merge(Zizia::Ability.new(current_user))
+      end
+  end
+end

--- a/app/models/zizia/ability.rb
+++ b/app/models/zizia/ability.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Zizia
+  class Ability
+    include Hydra::Ability
+    include Hyrax::Ability
+    self.ability_logic += [:everyone_can_create_curation_concerns]
+
+    # Define any customized permissions here.
+    def custom_permissions
+      can :manage, Zizia::CsvImport if current_user.admin?
+      can :manage, Zizia::CsvImportDetail if current_user.admin?
+      can :manage, Zizia::PreIngestWork if current_user.admin?
+    end
+  end
+end

--- a/app/models/zizia/csv_import_detail.rb
+++ b/app/models/zizia/csv_import_detail.rb
@@ -9,10 +9,6 @@ module Zizia
     has_many :pre_ingest_works
     has_many :pre_ingest_files, through: :pre_ingest_works
 
-    def status
-      'undetermined'
-    end
-
     def total_size
       return 0 if pre_ingest_files.empty?
       pre_ingest_files.map(&:size).sum

--- a/app/models/zizia/pre_ingest_work.rb
+++ b/app/models/zizia/pre_ingest_work.rb
@@ -12,5 +12,20 @@ module Zizia
       return solr_title unless solr_title.nil?
       'This work\'s metadata has not been indexed yet.'
     end
+
+    # Returns thumbnail urls based on the work's deduplication_key
+    # @return [Array<String>] the work's thumbnail urls
+    def thumbnails
+      thumbnail_urls = []
+      return thumbnail_urls if deduplication_key.nil?
+      file_sets = ActiveFedora::SolrService.get("deduplication_key_tesim:#{deduplication_key}")
+                                           .dig('response', 'docs', 0, 'file_set_ids_ssim')
+      return thumbnail_urls unless file_sets
+      file_sets.each do |file_set_id|
+        thumbnail_urls.push(ActiveFedora::SolrService.get("id:#{file_set_id}")
+                              .dig('response', 'docs', 0, 'thumbnail_path_ss'))
+      end
+      thumbnail_urls
+    end
   end
 end

--- a/app/views/zizia/csv_import_details/index.html.erb
+++ b/app/views/zizia/csv_import_details/index.html.erb
@@ -9,7 +9,6 @@
     <th>Number of Works</th>
     <th>Number of Files</th>
     <th>Total Size</th>
-    <th>Status</th>
     <th>Overwrite Behavior Type</th>
   </tr>
   <% @csv_import_details.each do |csv_import_detail| %>
@@ -34,9 +33,6 @@
       </td>
       <td>
         <%= number_to_human_size(csv_import_detail.total_size) %>
-      </td>
-      <td>
-        <%= csv_import_detail.status %>
       </td>
       <td>
         <%= human_update_actor_stack(csv_import_detail.update_actor_stack) %>

--- a/app/views/zizia/csv_import_details/show.html.erb
+++ b/app/views/zizia/csv_import_details/show.html.erb
@@ -15,6 +15,7 @@
       <th>Title</th>
       <th>Files</th>
       <th>Date</th>
+      <th>Status</th>
     </tr>
   <% @pre_ingest_works.each do |pre_ingest_work| %>
     <tr>
@@ -30,8 +31,16 @@
       <td>
         <%= pre_ingest_work.created_at.strftime("%B %-d, %Y %H:%M") %>
       </td>
+      <td id="<%= "work-status-#{pre_ingest_work.deduplication_key}" %>">
+        <span class="glyphicon glyphicon-question-sign status-unknown"></span>
+      </td>
     </tr>
   <% end %>
   </table>
   <%= paginate @pre_ingest_works %>
 </div>
+<script>
+ $(document).on('turbolinks:load', function() {
+   Zizia.displayWorkStatus()
+ })
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Zizia::Engine.routes.draw do
 
   get 'csv_import_details/index'
   get 'csv_import_details/show/:id', to: 'csv_import_details#show', as: 'csv_import_detail'
+  get 'pre_ingest_works/thumbnails/:deduplication_key', to: 'pre_ingest_works#thumbnails'
 end

--- a/spec/controllers/pre_ingest_works_controller_spec.rb
+++ b/spec/controllers/pre_ingest_works_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Zizia::PreIngestWorksController, :clean, type: :controller do
+  routes { Zizia::Engine.routes }
+  let(:admin_user) { FactoryBot.create(:admin) }
+  let(:pre_ingest_work) { FactoryBot.create(:pre_ingest_work) }
+  let(:pre_ingest_file) { FactoryBot.create(:pre_ingest_file, pre_ingest_work_id: pre_ingest_work.id) }
+  let(:pre_ingest_file_without_file) { FactoryBot.create(:pre_ingest_file, pre_ingest_work_id: pre_ingest_work.id, filename: File.open([Zizia::Engine.root, '/', 'spec/fixtures/dog.jpg'].join)) }
+  let(:work) { Work.new(title: ['a title'], deduplication_key: pre_ingest_work.deduplication_key) }
+  let(:file_set) do
+    FactoryBot.create(:file_set,
+                      title: ['zizia.png'],
+                      content: File.open([Zizia::Engine.root, '/', 'spec/fixtures/zizia.png'].join))
+  end
+  let(:basename) { 'zizia.png' }
+  before do
+    work.ordered_members << file_set
+    work.save
+  end
+
+  describe 'GET thumbnails' do
+    context 'as a logged in user' do
+      it 'returns 200' do
+        allow(controller).to receive(:current_user).and_return(admin_user)
+        get :thumbnails, params: { deduplication_key: pre_ingest_work.deduplication_key, format: :json }
+        expect(response.status).to eq(200)
+      end
+
+      it 'returns an array of thumbail paths' do
+        file_set.save
+        allow(controller).to receive(:current_user).and_return(admin_user)
+        get :thumbnails, params: { deduplication_key: pre_ingest_work.deduplication_key, format: :json }
+        parsed_json = JSON.parse(response.body)
+        expect(parsed_json['thumbnails']).to be_an(Array)
+        expect(parsed_json['thumbnails'].empty?).to eq(false)
+      end
+
+      it 'returns an empty array if there aren\'t any thumbnails' do
+        allow(controller).to receive(:current_user).and_return(admin_user)
+        get :thumbnails, params: { deduplication_key: 'abc/1234', format: :json }
+        parsed_json = JSON.parse(response.body)
+        expect(parsed_json['thumbnails']).to be_an(Array)
+        expect(parsed_json['thumbnails'].empty?).to eq(true)
+      end
+    end
+
+    context 'as someone not logged in' do
+      it 'returns 401' do
+        get :thumbnails, params: { deduplication_key: pre_ingest_work.deduplication_key, format: :json }
+        expect(response.status).to eq(401)
+      end
+    end
+  end
+end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :file_set do
+    transient do
+      user { build(:user) }
+      title { nil }
+      content { nil }
+    end
+    after(:build) do |fs, evaluator|
+      fs.apply_depositor_metadata evaluator.user.user_key
+      fs.title = evaluator.title
+    end
+
+    after(:create) do |file, evaluator|
+      Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
+    end
+
+    trait :public do
+      read_groups { ["public"] }
+    end
+
+    trait :registered do
+      read_groups { ["registered"] }
+    end
+
+    factory :file_with_work do
+      after(:build) do |file, _evaluator|
+        file.title = ['testfile']
+      end
+      after(:create) do |file, evaluator|
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
+        create(:work, user: evaluator.user).members << file
+      end
+    end
+  end
+end

--- a/spec/factories/pre_ingest_file.rb
+++ b/spec/factories/pre_ingest_file.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     updated_at { Time.current }
     row_number { 1 }
     row { 'sample,row' }
-    filename { '/a/path/to/my.csv' }
+    filename { [Zizia::Engine.root, '/', 'spec/fixtures/zizia.png'].join }
     size { 100_203_424 }
   end
 end

--- a/spec/models/zizia/pre_ingest_file_spec.rb
+++ b/spec/models/zizia/pre_ingest_file_spec.rb
@@ -4,9 +4,15 @@ require 'rails_helper'
 RSpec.describe Zizia::PreIngestFile do
   let(:pre_ingest_work) { FactoryBot.create(:pre_ingest_work) }
   let(:pre_ingest_file) { FactoryBot.create(:pre_ingest_file, pre_ingest_work_id: pre_ingest_work.id) }
-  let(:basename) { 'my.csv' }
+  let(:pre_ingest_file_without_file) { FactoryBot.create(:pre_ingest_file, pre_ingest_work_id: pre_ingest_work.id, filename: File.open([Zizia::Engine.root, '/', 'spec/fixtures/dog.jpg'].join)) }
+  let(:file_set) do
+    FactoryBot.create(:file_set,
+                      title: ['zizia.png'],
+                      content: File.open([Zizia::Engine.root, '/', 'spec/fixtures/zizia.png'].join))
+  end
+  let(:basename) { 'zizia.png' }
 
   it 'can get the basename for the file' do
-    expect(pre_ingest_file.basename).to eq(basename)
+    expect(pre_ingest_file.basename).to eq basename
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require 'hydra-role-management'
 require 'byebug'
 require 'rails-controller-testing'
 require 'selenium-webdriver'
+require 'devise'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -38,6 +39,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include Devise::Test::ControllerHelpers, type: :controller
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
This adds a PreIngestWork controller that allows
you to get the thumbnail URLs for a work based on
the deduplication_key.

This is used by some JS that checks the thumbnail URLs
by only requesting headers from the URL. If the work's
files have been characterized the requests will return
200. That's used to change change the icon from a question
mark to a green check in the 'Works and Files' page.

This kind of status checking can't be used for individual files
right now because there isn't any unique information being
saved on the `FileSet` that would be present when the `PreIngestFile`
is created.

Connected to https://github.com/curationexperts/in-house/issues/423