### PR TITLE
Add ID as secondary sort order

### DIFF
--- a/app/controllers/zizia/csv_import_details_controller.rb
+++ b/app/controllers/zizia/csv_import_details_controller.rb
@@ -8,11 +8,11 @@ module Zizia
     def index
       @csv_import_details = if csv_import_detail_params[:user] && user_id
                               Zizia::CsvImportDetail
-                                .order(sort_column + ' ' + sort_direction)
+                                .order("#{sort_column} #{sort_direction}, id DESC")
                                 .where(depositor_id: user_id).page csv_import_detail_params[:page]
                             else
                               Zizia::CsvImportDetail
-                                .order(sort_column + ' ' + sort_direction).page csv_import_detail_params[:page]
+                                .order("#{sort_column} #{sort_direction}, id DESC").page csv_import_detail_params[:page]
                             end
     end
 

--- a/spec/dummy/spec/system/csv_import_details_page_spec.rb
+++ b/spec/dummy/spec/system/csv_import_details_page_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'viewing the csv import detail page', :clean, js: true do
   it 'displays the metadata when you visit the page' do
     visit ('/csv_import_details/index')
     expect(page).to have_content('ID')
-    click_on '1'
+    click_on '13'
     expect(page).to have_content('Total Size')
     expect(page).to have_content('Deduplication Key')
   end
@@ -73,7 +73,7 @@ RSpec.describe 'viewing the csv import detail page', :clean, js: true do
   it 'displays the metadata when you visit the page' do
     visit ('/csv_import_details/index')
     expect(page).to have_content('ID')
-    click_on '1'
+    click_on '13'
     expect(page).to have_content('Total Size')
   end
 
@@ -117,6 +117,7 @@ RSpec.describe 'viewing the csv import detail page', :clean, js: true do
 
   it 'has pagination for PreIngestWorks at 10' do
     visit('/csv_import_details/index')
+    click_on 'Next'
     click_on '4'
     expect(page).to have_content 'Next'
     click_on 'Next'


### PR DESCRIPTION
This adds ID as a secondary sort order
for the import details table.

Connected to https://github.com/curationexperts/in-house/issues/432