### PR TITLE
Rename migration to not conflict with Hyrax migrations

### DIFF
--- a/db/migrate/20190919145012_user_roles.rb
+++ b/db/migrate/20190919145012_user_roles.rb
@@ -1,4 +1,4 @@
-class UserRoles < ActiveRecord::Migration[5.0]
+class ZiziaUserRoles < ActiveRecord::Migration[5.0]
   def up
     unless table_exists?(:roles)
       create_table :roles do |t|


### PR DESCRIPTION
Right now both Zizia and Hyrax have a migration with the same name. Let's rename ours and avoid the conflict.

Connected to #73 