### PR TITLE
Display the Field Guide with dashboard and navbar

### DIFF
--- a/app/controllers/zizia/metadata_details_controller.rb
+++ b/app/controllers/zizia/metadata_details_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Zizia
   class MetadataDetailsController < ::ApplicationController
+    with_themed_layout 'dashboard'
+
     def show
       @details = MetadataDetails.instance.details(work_attributes:
                                                      WorkAttributes.instance)

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+Flipflop.configure do
+  feature :download_csv,
+          default: true,
+          description: "Allow the user to download a CSV template from the dashboard."
+
+  feature :import_csv,
+          default: true,
+          description: "Allow the user to start a CSV import from the dashboard."
+
+  feature :new_ui,
+          default: true,
+          description: "Show new UI features and workflows."
+
+  feature :read_only,
+          default: false,
+          description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
+end

--- a/spec/dummy/spec/system/metadata_details_page_spec.rb
+++ b/spec/dummy/spec/system/metadata_details_page_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Viewing the field guide' do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    login_as admin_user
+  end
+
   it 'renders correctly' do
     visit('/importer_documentation/guide')
     expect(page).to have_content('title')


### PR DESCRIPTION
We want the Field Guide to share the same layout as other
admin dashboard screens.