### PR TITLE
Display the Field Guide with dashboard layout

### DIFF
--- a/app/controllers/zizia/metadata_details_controller.rb
+++ b/app/controllers/zizia/metadata_details_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module Zizia
   class MetadataDetailsController < ::ApplicationController
+    with_themed_layout 'dashboard'
+
     def show
       @details = MetadataDetails.instance.details(work_attributes:
                                                      WorkAttributes.instance)

--- a/spec/dummy/spec/system/metadata_details_page_spec.rb
+++ b/spec/dummy/spec/system/metadata_details_page_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 include Warden::Test::Helpers
 
 RSpec.describe 'Viewing the field guide' do
+  let(:admin_user) { FactoryBot.create(:admin) }
+
+  before do
+    login_as admin_user
+  end
+  
   it 'renders correctly' do
     visit('/importer_documentation/guide')
     expect(page).to have_content('title')


### PR DESCRIPTION
We want the Field Guide to share the same layout as other
admin dashboard screens.

The dashboard layout assumes we're logged in, so we need to update
the tests to login to avoid breaking unrelated parts of the layout.