### PR TITLE
Add a link to the CSV template in the Field Guide

### DIFF
--- a/app/assets/stylesheets/zizia/_field_guide.scss
+++ b/app/assets/stylesheets/zizia/_field_guide.scss
@@ -4,6 +4,16 @@
   margin-top: 1em;
   margin-bottom: 1em;
   font-size: large;
+  width: 50em;
+  border-bottom: 5px solid lightgray;
+
+  p {
+    margin-bottom: 1em;
+  };
+}
+
+.guide-container {
+  width: 50em;
 }
 
 .delimiter {

--- a/app/views/zizia/metadata_details/show.html.erb
+++ b/app/views/zizia/metadata_details/show.html.erb
@@ -1,25 +1,32 @@
 <h2>Metadata Field Guide</h2>
 <div class="field-guide-intro">
   <p>
-  This is a dynamically generated guide to the metadata used in this application.
-  Many fields are multi-valued. To include multiple values in a single CSV cell,
-  separate them with the delimiter that has been configured for this application:
-  <span class="delimiter"><%= @delimiter %></span>
+    This is a dynamically generated guide to the metadata used in this application.
+    You can download a CSV template with the headers required to describe and import
+    your own collections.  Download the template and use the field descriptions below to help
+    guide filling out the import manifest for works and collections you would like
+    to import into your repository.
+  </p>
+
+  <p><a class="btn btn-primary btn-lg" id="import_template" href=<%= importer_documentation_csv_path %> data-turbolinks="false" ><span class="glyphicon glyphicon-save-file" aria-hidden="true"></span> Template for New Imports</a></p>
+
+  <p>
+    Some fields can accept multiple values. To include multiple values in a single CSV cell,
+    separate them with the delimiter that has been configured for this application:
+    <span class="delimiter"><%= @delimiter %></span>
   </p>
   <p>
-  Example:   <span class="delimiter">Value 1<%= @delimiter %>Value 2</span>
+    Example:   <span class="delimiter">Value 1<%= @delimiter %>Value 2</span>
   </p>
 </div>
 
-<% content_for :title, 'Importer Field Guide' %>
 <div class="guide-container">
-  <a class="btn btn-primary" href="/importer_documentation/profile">Download as CSV</a>
   <div class="metadata-field-guide">
     <% @details.each do |detail| %>
       <div class="metadata-field <%= system_field(detail) %>" <%= hide_system_field(detail) %>>
-        <h2 class="field-label">
+        <h3 class="field-label">
           <%= detail[:label] %>
-        </h2>
+        </h3>
         <div>
           <b>Attribute:</b>
           <%= detail[:attribute] %>

--- a/spec/views/zizia/metadata_details/show.html.erb_spec.rb
+++ b/spec/views/zizia/metadata_details/show.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "zizia/metadata_details/show.html.erb", type: :view do
+  before do
+    assign(:details, [{
+             attribute: 'title',
+             label: 'Title',
+             csv_header: 'title',
+             predicate: 'n/a',
+             multiple: 'true',
+             type: 'String',
+             validator: 'n/a',
+             required_on_form: 'true',
+             usage: 'none'
+           }])
+    assign(:delimiter, '|')
+    allow(view).to receive(:importer_documentation_csv_path).and_return('./csv')
+  end
+
+  it 'renders as html' do
+    render
+    expect(rendered).to match(/<h3 class="field-label">\s*Title\s*<\/h3>/)
+  end
+
+  it 'provides a link to the import template' do
+    render
+    expect(rendered).to have_link("import_template", href: './csv')
+  end
+end


### PR DESCRIPTION
Ensure the user can download the current version of the CSV template file
from the Metadata Field Guide.

Also adds additional formatting enhancements to the Field Guide.

![image](https://user-images.githubusercontent.com/3064318/131774235-544784e1-c15f-445c-a5c0-bfcf81ba3220.png)
