### PR TITLE
Identifiers with spaces break solr queries

### DIFF
--- a/spec/dummy/spec/fixtures/csv_import/csv_files_with_problems/collection_issue.csv
+++ b/spec/dummy/spec/fixtures/csv_import/csv_files_with_problems/collection_issue.csv
@@ -1,0 +1,2 @@
+identifier,object type,parent,title,creator,keyword,rights statement,visibility,files,resource type,contributor,abstract or summary,license,publisher,date created,subject,language,location,related url,bibliographic_citation,source,deduplication_key
+Test Collection,C,,Test Collection,"Lynn, Rachel",things|~|interesting things,http://rightsstatements.org/vocab/NKC/1.0/,authenticated,NGS-BOWF00049.jpg,,,,,,,,,,,,,Test Collection

--- a/spec/uploaders/zizia/csv_manfest_validator_spec.rb
+++ b/spec/uploaders/zizia/csv_manfest_validator_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Zizia::CsvManifestValidator, type: :model do
     uploader.remove!
   end
 
+  context "with a csv with an identifier with a space in it" do
+    let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'csv_import', 'csv_files_with_problems', 'collection_issue.csv') }
+    it "collects warnings and errors for invalid entries" do
+      validator.validate
+      expect(validator.errors).to include("Invalid Identifier in row 2: Test Collection. Whitespace is not allowed in Identifiers.")
+      expect(validator.errors).to include("Invalid Deduplication Key in row 2: Test Collection. Whitespace is not allowed in Deduplication Keys.")
+    end
+  end
+
   context "with a csv with missing required fields" do
     let(:path_to_file) { Rails.root.join('spec', 'fixtures', 'csv_import', 'csv_files_with_problems', 'row_missing_required_field.csv') }
 


### PR DESCRIPTION
- Disallow for now

See https://app.honeybadger.io/projects/59583/faults/81151747 for context
```
ActionView::Template::Error: RSolr::Error::Http - 400 Bad Request
Error: {
  "responseHeader":{
    "status":400,
    "QTime":0,
    "params":{
      "q":"deduplication_key_tesim:Test Dedup",
      "qt":"standard",
      "wt":"json"}},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",

URI: http://127.0.0.1:8983/solr/tenejo/select?wt=json&q=deduplication_key_tesim%3ATest+Dedup&qt=standard

Backtrace: /opt/tenejo/shared/bundle/ruby/2.6.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:206:in `rescue in execute'
/opt/tenejo/shared/bundle/ruby/2.6.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:196:in `execute'
/opt/tenejo/shared/bundle/ruby/2.6.0/gems/rsolr-2.3.0/lib/rsolr/client.rb:191:in `send_and_receive'
(eval):2:in `get'
/opt/tenejo/shared/bundle/ruby/2.6.0/gems/active-fedora-12.1.1/lib/active_fedora/solr_service.rb:44:in `get'
/opt/tenejo/shared/bundle/ruby/2.6.0/bundler/gems/zizia-457a5b2106e8/app/models/zizia/pre_ingest_work.rb:10:in `title'
/opt/tenejo/shared/bundle/ruby/2.6.0/bundler/gems/zizia-457a5b2106e8/app/views/zizia/csv_import_details/show.html.erb:25:in `block in __opt_tenejo_shared_bundle_ruby_______bundler_gems_zizia____a_b____e__app_views_zizia_csv_import_details_show_html_erb___4102358556758887139_70303950597020'
/opt/tenejo/shared/bundle/ruby/2.6.0/bundler/gems/zizia-457a5b2106e8/app/views/zizia/csv_import_details/show.html.erb:19:in `each'
/opt/tenejo/shared/bundle/ruby/2.6.0/bundler/gems/zizia-457a5b2106e8/app/views/zizia/csv_import_details/show.html.erb:19:in `__opt_tenejo_shared_bundle_ruby_______bundler_gems_zizia____a_b____e__app_views_zizia_csv_import_details_show_html_erb___4102358556758887139_70303950597020'
/opt/tenejo/shared/bundle/ruby/2.6.0/gems/actionview-5.2.4.6/lib/action_view/template.rb:159:in `block in render'
/opt/tenejo/shared/bundle/ruby/2.6.0/gems/activesupport-5.2.4.6/lib/active_support/notifications.rb:170:in `instrument'
```