### PR TITLE
Remove support for Ruby 2.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,6 @@ workflows:
                 ruby_version: 2.6.6
                 rails_version: 5.2.6
             - build:
-                name: ruby2-7-1_with_rails_5_2
+                name: ruby2-7-4_with_rails_5_2
                 ruby_version: 2.7.4
                 rails_version: 5.2.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,10 @@ workflows:
     ci:
         jobs:
             - build:
-                name: ruby2-5-8_with_rails_5_2
-                ruby_version: 2.5.8
-                rails_version: 5.2.4.3
-            - build:
                 name: ruby2-6-6_with_rails_5_2
                 ruby_version: 2.6.6
-                rails_version: 5.2.4.3
+                rails_version: 5.2.6
             - build:
                 name: ruby2-7-1_with_rails_5_2
-                ruby_version: 2.7.1
-                rails_version: 5.2.4.3
+                ruby_version: 2.7.4
+                rails_version: 5.2.6

--- a/zizia.gemspec
+++ b/zizia.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.require_paths = ['lib']
 
-  gem.required_ruby_version = '>= 2.3.4'
+  gem.required_ruby_version = '>= 2.6'
 
   gem.add_dependency 'active-fedora'
   gem.add_dependency 'kaminari'


### PR DESCRIPTION
Ruby 2.5 is reaching end of life, and some important tests are being very flaky on it. We are opting to remove support for Ruby 2.5